### PR TITLE
Remove whitespace trimming for file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ This tool has been tested on Linux only, and only on systems with sufficient RAM
 
 Required arguments:
 - `-r`: Path to file that lists input files line by line.
-**WARNING**: `buildindex` stops reading file name upon the first space (ASCII 0x20) character.
 - `-w`: Output directory where buildindex will create its output files to. The speed of this output directory is usually the bottleneck for the entire computation, i.e., choose your target wisely. Experiments with NVMe SSD cards have been very promising performance-wise. **WARNING**: buildindex will create approximately 2**24 ~= 17M files and subdirectories in this path. Make sure that you have sufficicly many i-nodes left.
 - `-n`: Maximum number of files that should be indexed. The default and current maximum is 1M files. If you plan to index more files, it is highly advised to partition your input files into multiple 1M sets and merge the indexes using *yarix-indexmerge*. The main reason for this limit is the amount of memory that `buildindex` would otherwise require.
 

--- a/malindex.py
+++ b/malindex.py
@@ -168,7 +168,7 @@ class Index():
                 with open(self.pathlistfile,  "rb") as f:
                     for i, l in enumerate(f):
                         if self.numsamples is None or i < self.numsamples:
-                            self.paths.append(l.split(b" ")[0].decode().rstrip("\n"))
+                            self.paths.append(l.decode())
             return self.paths[fid]
 
 class MergedIndex():
@@ -197,5 +197,5 @@ class MergedIndex():
         if not self.paths:
             with open(self.pathlistfile, "rb") as f:
                 for l in f:
-                    self.paths.append(l.split(b" ")[0].decode().rstrip("\n"))
+                    self.paths.append(l.decode())
         return self.paths[fid]

--- a/src/tools/buildindex.c
+++ b/src/tools/buildindex.c
@@ -598,11 +598,8 @@ void read_filenames() {
         path = fgets(fpathsbuf, sizeof(fpathsbuf), fpaths);
 
         if (!path) break;
-        for (n = 0; ; n++) {
-            if (path[n] == ' ' || path[n] == '\n') {
-                path[n] = '\0';
-                break;
-            }
+        for (n = strlen(path) - 1; isspace(path[n]); n--) {
+            path[n] = '\0';
         }
         assert(n < MAX_FILENAME_LENGTH);
         strncpy(filenames[filenames_num], path, MAX_FILENAME_LENGTH);

--- a/src/tools/buildindex.c
+++ b/src/tools/buildindex.c
@@ -596,15 +596,10 @@ void read_filenames() {
 
     while (path != NULL && filenames_num < MAX_NUM_FILE_NAMES && filenames_num < num_files_to_index) {
         path = fgets(fpathsbuf, sizeof(fpathsbuf), fpaths);
-
         if (!path) break;
-        for (n = strlen(path) - 1; isspace(path[n]); n--) {
-            path[n] = '\0';
-        }
         assert(n < MAX_FILENAME_LENGTH);
         strncpy(filenames[filenames_num], path, MAX_FILENAME_LENGTH);
         filenames_num++;
-
         cur_id++;
     }
 


### PR DESCRIPTION
Hi Michael and team, and thanks so much for sharing your research and tools with the community.
\
\
Since the publication of your paper, I've been interested in trying it out on several malware samples stored on my test server (Ubuntu 14.04), and finally got around to doing so today.

When it came to running `buildindex` to build my first index, I passed in a list of local files, and started seeing errors due to the assertion at [line 133 in `buildindex.c`](https://github.com/mbrengel/yarix/blob/master/src/tools/buildindex.c#L133) failing.

I noticed this occurred with file paths containing spaces (as well as a few others,  which may have had a carriage return or other whitespace character which got slipped into the path somehow). 

Reading through the README, it appears this is known and perhaps intentional, but I wasn't sure why that might be the case.

Looking through [`read_filenames()`](https://github.com/mbrengel/yarix/blob/master/src/tools/buildindex.c#L576), it looks like the intent of the block shown at [601](https://github.com/mbrengel/yarix/blob/master/src/tools/buildindex.c#L601) is to trim any whitespace from the file path, but since the loop starts from the _beginning_ of the path string, it will add a terminator at the first space or newline encountered and then break, which will trim a path like this:

```
/tmp/my malware file.exe
```

to

```
/tmp/my
```

even if the spaces are escaped or the path is quoted.  
\
\
The fix I propose in this PR instead starts iterating at the tail of the file path, and uses `isspace()` to determine if the character is not only a newline or space, but carriage return or any other whitespace.

This fix allowed me to complete indexing on my files.

Let me know if you have any feedback on the changes, and if I interpreted the intent of the code correctly.
\
\
As an aside, on Ubuntu 14.04, I also ran into several errors during the build stage, due to not compiling in C99 mode explicitly.

To fix this, I added a flag to the [Makefile](https://github.com/mbrengel/yarix/blob/master/src/Makefile) as follows:

```
CFLAGS += -std=gnu99 -Wall -Wextra -Wpedantic -Ofast
```

I did not include this in my PR since it may be unique  to my environment, but I wanted to mention it in the case that others have the same issue.

Again, thanks so much for your work, and I look forward to further testing of the tool!